### PR TITLE
fix: make methods in PLViewListener not final

### DIFF
--- a/library/src/main/java/com/panoramagl/PLViewListener.kt
+++ b/library/src/main/java/com/panoramagl/PLViewListener.kt
@@ -13,80 +13,80 @@ import com.panoramagl.transitions.PLITransition
 
 @Suppress("UNUSED_PARAMETER")
 abstract class PLViewListener {
-    fun onTouchesBegan(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onTouchesMoved(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onTouchesEnded(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onTouchesBegan(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onTouchesMoved(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onTouchesEnded(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onDidBeginTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
+    open fun onDidMoveTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?): Boolean {
         return true
     }
 
-    fun onDidEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
-    fun onShouldAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?): Boolean {
+    open fun onDidEndTouching(view: PLIView?, touches: List<UITouch?>?, event: MotionEvent?) {}
+    open fun onShouldAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?): Boolean {
         return true
     }
 
-    fun onDidAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?) {}
-    fun onShouldBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidAccelerate(view: PLIView?, acceleration: UIAcceleration?, event: SensorEvent?) {}
+    open fun onShouldBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidBeginInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onDidEndInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldBeingScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
+    open fun onDidRunInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onDidEndInertia(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldBeingScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?): Boolean {
         return true
     }
 
-    fun onDidBeginScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onDidEndScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldBeginZooming(view: PLIView?): Boolean {
+    open fun onDidBeginScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onDidEndScrolling(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldBeginZooming(view: PLIView?): Boolean {
         return true
     }
 
-    fun onDidBeginZooming(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
-    fun onShouldRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean): Boolean {
+    open fun onDidBeginZooming(view: PLIView?, startPoint: CGPoint?, endPoint: CGPoint?) {}
+    open fun onShouldRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean): Boolean {
         return true
     }
 
-    fun onDidRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean) {}
-    fun onDidEndZooming(view: PLIView?) {}
-    fun onShouldReset(view: PLIView?): Boolean {
+    open fun onDidRunZooming(view: PLIView?, distance: Float, isZoomIn: Boolean, isZoomOut: Boolean) {}
+    open fun onDidEndZooming(view: PLIView?) {}
+    open fun onShouldReset(view: PLIView?): Boolean {
         return true
     }
 
-    fun onDidReset(view: PLIView?) {}
-    fun onDidBeginCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
-    fun onDidEndCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
-    fun onDidResetCamera(view: PLIView?, sender: Any?, camera: PLICamera?) {}
-    fun onDidLookAtCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, animated: Boolean) {}
-    fun onDidRotateCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, roll: Float) {}
-    fun onDidFovCamera(view: PLIView?, sender: Any?, camera: PLICamera?, fov: Float, animated: Boolean) {}
-    fun onDidOverElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidClickElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOutElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOverHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidClickHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidOutHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
-    fun onDidBeginTransition(view: PLIView?, transition: PLITransition?) {}
-    fun onDidProcessTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
-    fun onDidStopTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
-    fun onDidEndTransition(view: PLIView?, transition: PLITransition?) {}
-    fun onDidBeginLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidCompleteLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidStopLoader(view: PLIView?, loader: PLILoader?) {}
-    fun onDidErrorLoader(view: PLIView?, loader: PLILoader?, error: String?) {}
+    open fun onDidReset(view: PLIView?) {}
+    open fun onDidBeginCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
+    open fun onDidEndCameraAnimation(view: PLIView?, sender: Any?, camera: PLICamera?, type: PLCameraAnimationType?) {}
+    open fun onDidResetCamera(view: PLIView?, sender: Any?, camera: PLICamera?) {}
+    open fun onDidLookAtCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, animated: Boolean) {}
+    open fun onDidRotateCamera(view: PLIView?, sender: Any?, camera: PLICamera?, pitch: Float, yaw: Float, roll: Float) {}
+    open fun onDidFovCamera(view: PLIView?, sender: Any?, camera: PLICamera?, fov: Float, animated: Boolean) {}
+    open fun onDidOverElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidClickElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOutElement(view: PLIView?, element: PLISceneElement?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOverHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidClickHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidOutHotspot(view: PLIView?, hotspot: PLIHotspot?, screenPoint: CGPoint?, scene3DPoint: PLPosition?) {}
+    open fun onDidBeginTransition(view: PLIView?, transition: PLITransition?) {}
+    open fun onDidProcessTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
+    open fun onDidStopTransition(view: PLIView?, transition: PLITransition?, progressPercentage: Int) {}
+    open fun onDidEndTransition(view: PLIView?, transition: PLITransition?) {}
+    open fun onDidBeginLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidCompleteLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidStopLoader(view: PLIView?, loader: PLILoader?) {}
+    open fun onDidErrorLoader(view: PLIView?, loader: PLILoader?, error: String?) {}
 }


### PR DESCRIPTION
Final methods in PLViewListener.kt makes impossible to override them to use in PLManager.setListener()